### PR TITLE
Remove port from hypixelbot.ga's API URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - Gopine Client Repository [[here](https://github.com/GopineClient/gopine-client)]
 ### Hypixel Bot
 - Hypixel Bot [[top.gg](https://top.gg/bot/730063696130211901)] [[GitHub](https://github.com/matthewtgm/hypixel-bot)]\
-- Hypixel Bot API [[Base URL](http://hypixelbot.ga:2158/api)]\
+- Hypixel Bot API [[Base URL](http://hypixelbot.ga/api)]\
 [![Discord Bots](https://top.gg/api/widget/730063696130211901.svg)](https://top.gg/bot/730063696130211901)
 
 ### TeamTGM


### PR DESCRIPTION
Without this fix, the URL is invalid.